### PR TITLE
Cleaning up branches GraphQL query

### DIFF
--- a/src/V4/Raw/Repository/branches.graphql
+++ b/src/V4/Raw/Repository/branches.graphql
@@ -22,7 +22,6 @@ query ($owner: String!, $name: String!) {
                                     name
                                     __typename
                                     avatarUrl
-                                    url
                                     isSiteAdmin
                                 }
                             }
@@ -36,21 +35,16 @@ query ($owner: String!, $name: String!) {
                                     name
                                     __typename
                                     avatarUrl
-                                    url
                                     isSiteAdmin
                                 }
                             }
                             tree {
                                 oid
-                                commitUrl
-                                commitResourcePath
                             }
                             parents(first: 100) {
                                 edges {
                                     node {
                                         oid
-                                        url
-                                        commitUrl
                                     }
                                 }
                             }

--- a/src/V4/Raw/Repository/branches.graphql
+++ b/src/V4/Raw/Repository/branches.graphql
@@ -1,7 +1,5 @@
 query ($owner: String!, $name: String!) {
     repository(owner: $owner, name: $name) {
-        id
-        name
         refs(refPrefix: "refs/heads/", first: 100) {
             edges {
                 node {

--- a/src/V4/Raw/Repository/branches.graphql
+++ b/src/V4/Raw/Repository/branches.graphql
@@ -3,7 +3,6 @@ query ($owner: String!, $name: String!) {
         refs(refPrefix: "refs/heads/", first: 100) {
             edges {
                 node {
-                    id
                     name
                     target {
                         ... on Commit {


### PR DESCRIPTION
- We dont need branch id when fetching branches
 - We dont need repository id or name when fetching branches
 - Remove various urls when fetching branches

Closes #59